### PR TITLE
Fix reason to call xcape twice.

### DIFF
--- a/caps2esc
+++ b/caps2esc
@@ -5,7 +5,7 @@ proc=$(ps aux|grep xcape|grep -v grep|awk '{ print $2}'|xargs)
 if [[ "${proc}" == "" ]]; then
 	echo "No old processes."
 else
-	echo "Old processes: \n ${proc}"
+	echo -e "Old processes:\n ${proc}"
 	kill -9 ${proc} 2>>/dev/null
 fi
 

--- a/caps2esc
+++ b/caps2esc
@@ -9,6 +9,5 @@ else
 	kill -9 ${proc} 2>>/dev/null
 fi
 
-xcape
 xmodmap ${HOME}/.xmodmap.conf
 xcape

--- a/xmodmap.conf
+++ b/xmodmap.conf
@@ -1,10 +1,10 @@
 ! make caps_lock an additional control
-clear Lock
 keycode 66 = Control_L
 add Control = Control_L
 
 ! make escape be caps_lock
-keysym Escape = Caps_Lock
+clear Lock
+keycode 9 = Caps_Lock
 add Lock = Caps_Lock
 
 ! make a fake escape key (so we can map it with xcape)


### PR DESCRIPTION
It seems the reason to call xcape twice relates to a previously
configured xmodmap state, and calling it twice doesn't solve the
issue correctly. For example, from xmodmap manpages:

```
One of the more irritating differences between keyboards is the
location of the Control and CapsLock keys.  A common use of xmodmap
is to swap these two keys as follows:

!
! Swap Caps_Lock and Control_L
!
remove Lock = Caps_Lock
remove Control = Control_L
keysym Control_L = Caps_Lock
keysym Caps_Lock = Control_L
add Lock = Caps_Lock
add Control = Control_L

This example can be run again to swap the keys back to their
previous assignments.
```

As can be seen, this example is used to swap configuration once the
script is executed a second time. It seems the same was happening
with the script from xmodmap.conf at the line with:

```
keysym Escape = Caps_Lock
```

Calling xcape twice was hiding this, but not to great effect because
sometimes both Escape and CapsLock got generated when pressing the
CapsLock key.

Another side effect when the shell is configured for vi mode was having
to press CapsLock twice in the command line to go to Normal mode. This
effect didn't show up in Vim though.

To solve what was the apparent problem I've used hard coded keycode
mapping for Escape instead of using keysym.

I've tried this on Arch to great effect, didn't try it on Ubuntu yet.
